### PR TITLE
Fixed minitest-rails capability

### DIFF
--- a/lib/keynote/testing/minitest_rails.rake
+++ b/lib/keynote/testing/minitest_rails.rake
@@ -1,18 +1,7 @@
 # encoding: UTF-8
 
-require "rake/testtask"
-require "minitest/rails/testing"
-require "minitest/rails/tasks/sub_test_task"
-
-MiniTest::Rails::Testing.default_tasks << "presenters"
-
-namespace "minitest" do
-  unless Rake::Task.task_defined? "minitest:presenters"
-    desc "Runs tests under test/presenters"
-    MiniTest::Rails::Tasks::SubTestTask.new("presenters" => "test:prepare") do |t|
-      t.libs.push "test"
-      t.pattern = "test/presenters/**/*_test.rb"
-      t.options = MiniTest::Rails::Testing.task_opts["presenters"] if MiniTest::Rails::Testing.task_opts["presenters"]
-    end
-  end
+Rails::TestTask.new("test:presenters" => "test:prepare") do |t|
+  t.pattern = "test/presenters/**/*_test.rb"
 end
+
+Rake::Task["test:run"].enhance ["test:presenters"]


### PR DESCRIPTION
`minitest/rails/testing` doesn’t exist anymore and there is a shorter way to declare a new test task.
Otherwise it's raising with 
```
LoadError: cannot load such file -- minitest/rails/testing
```

More docs: https://github.com/blowmage/minitest-rails/blob/cf2302bcec7d7620819c744e84e26c4452eed4be/README.rdoc#running-tests
