### PR TITLE
fix escaping symbols

### DIFF
--- a/lib/keynote/rumble.rb
+++ b/lib/keynote/rumble.rb
@@ -339,7 +339,7 @@ module Keynote
             if value.is_a?(Array)
               value.map { |val| Rumble.html_escape(val) }.join(" ")
             elsif value == true
-              name
+              name.to_s
             else
               Rumble.html_escape(value)
             end

--- a/spec/rumble_spec.rb
+++ b/spec/rumble_spec.rb
@@ -65,6 +65,12 @@ class TestRumble < klass
     end
   end
 
+  def test_true_as_value
+    assert_rumble '<input disabled="disabled">' do
+      input disabled: true
+    end
+  end
+
   def test_hash_data
     str = <<-HTML
       <div data-modal="true" data-safe="&quot;&quot;&quot;" data-unsafe="&quot;&amp;quot;&quot;">


### PR DESCRIPTION
fix
```
undefined method `gsub' for :disabled:Symbol (NoMethodError)
```

on code like:

```ruby
input(type: 'checkbox', name: 'employers[]', disabled: !Rails.env.production?)
```